### PR TITLE
ci: update deprecated GitHub Actions so workflows run again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,28 +24,34 @@ jobs:
         # The token is only needed for privileged actions from within the repo, so no need
         # to make it available on 3rd party PRs
         if: ${{ fromJSON(env.PRIVILEGED_RUN) }}
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
-          token: ${{ secrets.SORMAS_VITAGROUP_TOKEN }}
+          # Fall back to the built-in token so the workflow still runs in forks,
+          # where the SORMAS_VITAGROUP_TOKEN secret is not available.
+          token: ${{ secrets.SORMAS_VITAGROUP_TOKEN || github.token }}
 
       - name: Checkout repository (without token)
         # Check if PR results from a fork: if yes, we cannot access the token.
         # The token is only needed for privileged actions from within the repo, so no need
         # to make it available on 3rd party PRs
         if: ${{ !fromJSON(env.PRIVILEGED_RUN) }}
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Set up JDK ${{ env.JAVA }}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ env.JAVA }}
+          # setup-java v2+ requires an explicit distribution. Zulu matches the
+          # JDK recommended in the project's development setup docs and is what
+          # setup-java@v1 installed by default, so the toolchain is unchanged.
+          distribution: 'zulu'
 
       - name: Cache Maven packages
         # Check if PR results from the repository: if yes, it is safe to cache dependencies.
         # This is to keep us safe from cache poisoning through 3rd party PRs.
         if: ${{ fromJSON(env.PRIVILEGED_RUN) }}
         # FIXME(@JonasCir) #3733 remove '**/*.pom' once serverlib pom is renamed
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.m2
           key: ${{ runner.os }}-java-${{ env.JAVA }}-m2-${{ hashFiles('**/pom.xml', '**/*.pom') }}

--- a/.github/workflows/github_pages.yml
+++ b/.github/workflows/github_pages.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout development
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
       - name: Copy files
         run: |
           cp README.md docs/index.md

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -27,7 +27,9 @@ jobs:
     # Name the Job
     name: Lint Code Base
     # Set the agent to run on
-    runs-on: Ubuntu-20.04
+    # ubuntu-20.04 runners were retired by GitHub; jobs requesting that label
+    # are never scheduled and end up cancelled.
+    runs-on: ubuntu-latest
 
     ##################
     # Load all steps #
@@ -37,7 +39,7 @@ jobs:
       # Checkout the code base #
       ##########################
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           # Full git history is needed to get a proper list of changed files within `super-linter`
           fetch-depth: 0

--- a/.github/workflows/openapi_canary.yml
+++ b/.github/workflows/openapi_canary.yml
@@ -13,12 +13,12 @@ jobs:
 
     steps:
       - name: Checkout development branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           path: head
 
       - name: Checkout master branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: master
           path: base


### PR DESCRIPTION
GitHub now auto-fails any job that references actions/cache@v2. Because the "Java CI with Maven" job pins that version, it is rejected during "Set up job" and terminates in ~2s without executing a single build step. Every retained run of that workflow has failed for this reason, so `mvn verify` has not actually run in CI for the full 90-day retention window.

Two of the other three workflows are broken the same way:
  - Lint Code Base targets `Ubuntu-20.04`, a runner label GitHub has retired, so its jobs are never scheduled and end up cancelled.
  - Publish GitHub Pages pins actions/checkout@v1.

Changes:
  - actions/cache      v2 -> v4   (the hard blocker)
  - actions/checkout   v1/v2 -> v4  (all workflows)
  - actions/setup-java v1 -> v4, adding the now-required `distribution`.
    Zulu is used because that is what setup-java@v1 installed by default
    and what the development setup docs recommend, so the JDK is
    unchanged.
  - Lint Code Base now runs on `ubuntu-latest`.
  - The privileged checkout falls back to the built-in `github.token`
    when SORMAS_VITAGROUP_TOKEN is absent, so CI also works in forks.

No build logic, no test scope, and no toolchain versions are changed. Verified with actionlint (clean).

<!--
If you've never submitted a pull request to the SORMAS repository before or this is your first time using this template, please read the Contributing guidelines (https://github.com/hzi-braunschweig/SORMAS-Project/blob/development/docs/CONTRIBUTING.md) for an explanation of our guidelines regarding pull requests. You don't have to remove this comment or from your pull request as it will automatically be hidden.

Please specify the number of the issue this pull request is related to after the #.
-->
Fixes #